### PR TITLE
회사 모달 및 디자인 피드백

### DIFF
--- a/src/components/common/AddCompanyDialog/AddCompanyDialog.tsx
+++ b/src/components/common/AddCompanyDialog/AddCompanyDialog.tsx
@@ -1,0 +1,48 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+
+import CompanyInfoForm from '../CompanyInfoForm/CompanyInfoForm';
+
+type AddCompanyDialogProps = {
+  TriggerButton: React.ReactNode;
+};
+
+function AddCompanyDialog({ TriggerButton }: AddCompanyDialogProps) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>{TriggerButton}</AlertDialogTrigger>
+      <AlertDialogContent
+        className="min-w-[936px]"
+        aria-describedby="회사 정보를 입력해주세요."
+      >
+        <AlertDialogTitle>
+          <div className="flex flex-col gap-1.5">
+            <strong className="text-2xl font-semibold ">
+              지원하고자 하는 회사의 정보를 입력해주세요.
+            </strong>
+            <span className="text-sm text-muted-foreground font-normal">
+              관련 공고 URL 및 간단한 회사 설명을 함께 작성해주시면 정확도가 더
+              올라가요.
+            </span>
+          </div>
+        </AlertDialogTitle>
+
+        <CompanyInfoForm />
+
+        <AlertDialogFooter className="sm:justify-between mt-[26px]">
+          <AlertDialogCancel>취소</AlertDialogCancel>
+          <AlertDialogAction>확인</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+export default AddCompanyDialog;

--- a/src/components/common/CompanyInfoForm/CompanyInfoForm.tsx
+++ b/src/components/common/CompanyInfoForm/CompanyInfoForm.tsx
@@ -1,0 +1,177 @@
+import { Button } from '@/components/ui/button';
+import {
+  Command,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+import { Check, ChevronsUpDown } from 'lucide-react';
+import { useState } from 'react';
+
+const EMPLOYMENT_TYPE = [
+  {
+    value: '정규직',
+    label: '정규직',
+  },
+  {
+    value: '계약직',
+    label: '계약직',
+  },
+  {
+    value: '인턴',
+    label: '인턴',
+  },
+  {
+    value: '프리랜서',
+    label: '프리랜서',
+  },
+];
+
+type CompanyInfoFormProps = {
+  company?: string;
+  job?: string;
+  type?: string;
+  url?: string;
+  description?: string;
+};
+
+function CompanyInfoForm({
+  company = '',
+  job = '',
+  type = '',
+  url = '',
+  description = '',
+}: CompanyInfoFormProps) {
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState({ company, job, type, url, description });
+  const handleInputChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    type: string,
+  ) => {
+    setValue((prev) => ({ ...prev, [type]: e.target.value }));
+  };
+
+  return (
+    <div id="회사 정보를 입력해주세요." className="flex flex-col gap-4">
+      <div className="flex gap-4">
+        <div>
+          <Label htmlFor="company" isRequired>
+            회사명
+          </Label>
+          <Input
+            id="company"
+            className="w-[323px]"
+            type="text"
+            placeholder="지원하려고 하는 회사명을 입력해주세요."
+            value={value.company}
+            onChange={(e) => handleInputChange(e, 'company')}
+            required
+          />
+        </div>
+
+        <div className="w-full">
+          <Label htmlFor="job" isRequired>
+            직무 선택
+          </Label>
+          <Input
+            id="job"
+            type="text"
+            placeholder="지원하려는 직무를 선택해주세요."
+            value={value.job}
+            onChange={(e) => handleInputChange(e, 'job')}
+            required
+          />
+        </div>
+
+        <div className="w-full">
+          <Label htmlFor="type">채용 형태</Label>
+          <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                id="type"
+                variant="outline"
+                role="combobox"
+                aria-expanded={open}
+                className={cn(
+                  'flex justify-between w-full',
+                  !value.type && 'text-muted-foreground',
+                )}
+              >
+                {value.type || '채용 형태를 선택해주세요.'}
+                <ChevronsUpDown className="opacity-50" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-[200px] p-0">
+              <Command>
+                <CommandList>
+                  <CommandGroup>
+                    {EMPLOYMENT_TYPE.map((type) => (
+                      <CommandItem
+                        key={type.value}
+                        value={type.value}
+                        onSelect={(currentValue) => {
+                          setValue((prev) => ({ ...prev, type: currentValue }));
+                          setOpen(false);
+                        }}
+                      >
+                        {type.label}
+                        <Check
+                          className={cn(
+                            'ml-auto',
+                            value.type === type.value
+                              ? 'opacity-100'
+                              : 'opacity-0',
+                          )}
+                        />
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
+        </div>
+      </div>
+
+      <div>
+        <Label htmlFor="url">관련 공고 URL</Label>
+        <div className="relative">
+          <span className="absolute top-1/2 left-3 -translate-y-1/2  text-sm text-muted-foreground ">
+            https://
+          </span>
+          <div className="absolute left-[68px] w-px bg-input h-9" />
+          <Input
+            id="url"
+            className="pl-[78px]"
+            type="text"
+            placeholder="example.com"
+            value={value.url}
+            onChange={(e) => handleInputChange(e, 'url')}
+          />
+        </div>
+      </div>
+
+      <div>
+        <Label htmlFor="description">회사 설명</Label>
+        <Textarea
+          id="description"
+          placeholder="더욱 정확한 정보를 위한 설명도 함께 작성해주세요."
+          className="min-h-40"
+          value={value.description}
+          onChange={(e) => handleInputChange(e, 'description')}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default CompanyInfoForm;

--- a/src/components/layout/AppSidebar/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar/AppSidebar.tsx
@@ -208,9 +208,6 @@ function AppSidebar() {
                                     자기소개서
                                   </SidebarMenuSubButton>
                                 </Link>
-                                <SidebarMenuSubButton>
-                                  예상 면접 질문
-                                </SidebarMenuSubButton>
                               </SidebarMenuSub>
                             </CollapsibleContent>
                           </Collapsible>

--- a/src/components/layout/AppSidebar/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar/AppSidebar.tsx
@@ -14,7 +14,7 @@ import {
 } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
-import { Link } from 'react-router';
+import { Link, useLocation, useParams } from 'react-router';
 import {
   Sidebar,
   SidebarContent,
@@ -49,8 +49,12 @@ function AppSidebar() {
   const [isContentVisible, setIsContentVisible] = useState(open);
   const [isCompanySectionOpen, setIsCompanySectionOpen] = useState(false);
   const [companyOpenMap, setCompanyOpenMap] = useState<{
-    [key: number]: boolean;
-  }>({ 0: true });
+    [key: string]: boolean;
+  }>({});
+
+  const location = useLocation();
+  const params = useParams();
+  const lastPath = location.pathname.split('/').pop() ?? '';
 
   const handleSidebarOpenIconClick = () => {
     if (open) return;
@@ -62,8 +66,8 @@ function AppSidebar() {
     else handleSidebarOpenIconClick();
   };
 
-  const toggleCompaniesMenu = (i: number, isOpen: boolean) => {
-    setCompanyOpenMap((prev) => ({ ...prev, [i]: isOpen }));
+  const toggleCompaniesMenu = (company: string, isOpen: boolean) => {
+    setCompanyOpenMap((prev) => ({ ...prev, [company]: isOpen }));
   };
 
   /** 사이드바 열림/닫힘 애니메이션에 맞춰 콘텐츠 표시 제어 */
@@ -160,9 +164,9 @@ function AppSidebar() {
                       {COMPANY_LIST.map((company, i) => (
                         <SidebarMenuItem key={company} className="pl-3.5 ">
                           <Collapsible
-                            open={!!companyOpenMap[i]}
+                            open={!!companyOpenMap[company]}
                             onOpenChange={(open) =>
-                              toggleCompaniesMenu(i, open)
+                              toggleCompaniesMenu(company, open)
                             }
                           >
                             <CollapsibleTrigger asChild>
@@ -185,12 +189,22 @@ function AppSidebar() {
                             <CollapsibleContent>
                               <SidebarMenuSub>
                                 <Link to={`/companies/${company}/experience`}>
-                                  <SidebarMenuSubButton isActive={i === 0}>
+                                  <SidebarMenuSubButton
+                                    isActive={
+                                      params.company === company &&
+                                      lastPath === 'experience'
+                                    }
+                                  >
                                     경험정리
                                   </SidebarMenuSubButton>
                                 </Link>
                                 <Link to={`/companies/${company}/coverletter`}>
-                                  <SidebarMenuSubButton>
+                                  <SidebarMenuSubButton
+                                    isActive={
+                                      params.company === company &&
+                                      lastPath === 'coverletter'
+                                    }
+                                  >
                                     자기소개서
                                   </SidebarMenuSubButton>
                                 </Link>

--- a/src/components/layout/AppSidebar/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar/AppSidebar.tsx
@@ -36,6 +36,7 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible';
 import LogoTitle from '@/components/common/LogoTitle';
+import AddCompanyDialog from '@/components/common/AddCompanyDialog/AddCompanyDialog';
 
 const COMPANY_LIST = ['회사명 1', '회사명 2', '회사명 3'];
 const MENU_LIST = [
@@ -221,11 +222,17 @@ function AppSidebar() {
 
             {isContentVisible && (
               <SidebarMenuItem>
-                <SidebarMenuButton className="flex justify-between">
-                  <span className="text-sidebar-foreground/70">회사 추가</span>
+                <AddCompanyDialog
+                  TriggerButton={
+                    <SidebarMenuButton className="flex justify-between">
+                      <span className="text-sidebar-foreground/70">
+                        회사 추가
+                      </span>
 
-                  <Plus />
-                </SidebarMenuButton>
+                      <Plus />
+                    </SidebarMenuButton>
+                  }
+                />
               </SidebarMenuItem>
             )}
           </SidebarMenu>

--- a/src/components/layout/CompaniesLayout/CompaniesLayout.tsx
+++ b/src/components/layout/CompaniesLayout/CompaniesLayout.tsx
@@ -16,13 +16,11 @@ export type ExperienceSidebarContextType = [
 const PATH_LIST = [
   { path: 'experience', label: '경험정리' },
   { path: 'coverletter', label: '자기소개서' },
-  { path: 'interview', label: '예상 면접 질문' },
 ];
 
 const PAGE_TITLE_MAP: Record<string, string> = {
   experience: '경험정리',
   coverletter: '자기소개서',
-  interview: '예상 면접 질문',
 };
 
 function CompaniesLayout() {

--- a/src/components/layout/CompaniesLayout/CompaniesLayout.tsx
+++ b/src/components/layout/CompaniesLayout/CompaniesLayout.tsx
@@ -6,6 +6,7 @@ import blankcompany from '@/assets/images/blank-company.svg';
 import Tag from '@/components/common/Tag/Tag';
 import { useState } from 'react';
 import ManageCoverletterDialog from './ManageCoverletterDialog/ManageCoverletterDialog';
+import ManageCompanyDialog from './ManageCompanyDialog/ManageCompanyDialog';
 
 export type ExperienceSidebarContextType = [
   boolean,
@@ -109,7 +110,7 @@ function CompaniesLayout() {
             <span className="text-sm">지원 직무: 프로덕트 디자이너</span>
           </div>
 
-          <ChevronRight />
+          <ManageCompanyDialog />
         </div>
       </header>
 

--- a/src/components/layout/CompaniesLayout/ManageCompanyDialog/ManageCompanyDialog.tsx
+++ b/src/components/layout/CompaniesLayout/ManageCompanyDialog/ManageCompanyDialog.tsx
@@ -1,0 +1,59 @@
+import CompanyInfoForm from '@/components/common/CompanyInfoForm/CompanyInfoForm';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import { ChevronRight } from 'lucide-react';
+import blankcompany from '@/assets/images/blank-company.svg';
+
+function ManageCompanyDialog() {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant={'ghost'} size={'icon'}>
+          <ChevronRight className="size-6" />
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent
+        className="min-w-[936px]"
+        aria-describedby="회사 정보를 입력해주세요."
+      >
+        <AlertDialogTitle>
+          <div className="flex items-center gap-5">
+            <img src={blankcompany} alt="회사이미지" />
+            <strong className="text-2xl font-semibold ">회사명</strong>
+          </div>
+        </AlertDialogTitle>
+
+        <CompanyInfoForm
+          company="회사이름"
+          job="회사직무"
+          type="정규직"
+          url="회사주소.com"
+          description="회사 설명이 들어갑니다."
+        />
+
+        <AlertDialogFooter className="sm:justify-between mt-8">
+          <Button variant={'destructive'} size={'lg'}>
+            삭제하기
+          </Button>
+
+          <div className="flex gap-2.5">
+            <AlertDialogCancel className="h-10">취소</AlertDialogCancel>
+            <AlertDialogAction className="h-10">
+              변동사항 저장하기
+            </AlertDialogAction>
+          </div>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+export default ManageCompanyDialog;

--- a/src/pages/CompaniesPage/CompaniesPage.tsx
+++ b/src/pages/CompaniesPage/CompaniesPage.tsx
@@ -1,13 +1,4 @@
-import CompanyInfoForm from '@/components/common/CompanyInfoForm/CompanyInfoForm';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogFooter,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
+import AddCompanyDialog from '@/components/common/AddCompanyDialog/AddCompanyDialog';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { Plus } from 'lucide-react';
@@ -45,37 +36,15 @@ function CompaniesPage() {
         <h4 className={cn('typo-h4 text-zinc-700', !hasData && 'mb-10')}>
           회사와 관련 공고 등록하고 맞춤 자기소개서를 생성해보세요.
         </h4>
-        <AlertDialog>
-          <AlertDialogTrigger asChild>
+
+        <AddCompanyDialog
+          TriggerButton={
             <Button className="h-11">
               <Plus />
               회사 추가
             </Button>
-          </AlertDialogTrigger>
-          <AlertDialogContent
-            className="min-w-[936px]"
-            aria-describedby="회사 정보를 입력해주세요."
-          >
-            <AlertDialogTitle>
-              <div className="flex flex-col gap-1.5">
-                <strong className="text-2xl font-semibold ">
-                  지원하고자 하는 회사의 정보를 입력해주세요.
-                </strong>
-                <span className="text-sm text-muted-foreground font-normal">
-                  관련 공고 URL 및 간단한 회사 설명을 함께 작성해주시면 정확도가
-                  더 올라가요.
-                </span>
-              </div>
-            </AlertDialogTitle>
-
-            <CompanyInfoForm />
-
-            <AlertDialogFooter className="sm:justify-between mt-[26px]">
-              <AlertDialogCancel>취소</AlertDialogCancel>
-              <AlertDialogAction>확인</AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+          }
+        />
       </div>
 
       {hasData && (

--- a/src/pages/CompaniesPage/CompaniesPage.tsx
+++ b/src/pages/CompaniesPage/CompaniesPage.tsx
@@ -22,6 +22,8 @@ const DATA = [
   { id: 6, name: '쿠팡', job: '프로덕트 디자이너' },
 ];
 
+// const DATA = [];
+
 function CompaniesPage() {
   const hasData = DATA.length > 0;
 
@@ -36,7 +38,9 @@ function CompaniesPage() {
         회사별 맞춤 관리
       </h3>
       <div
-        className={cn(hasData ? 'flex justify-between mb-10' : 'text-center')}
+        className={cn(
+          hasData ? 'flex justify-between items-center mb-10' : 'text-center',
+        )}
       >
         <h4 className={cn('typo-h4 text-zinc-700', !hasData && 'mb-10')}>
           회사와 관련 공고 등록하고 맞춤 자기소개서를 생성해보세요.

--- a/src/pages/CompaniesPage/CompaniesPage.tsx
+++ b/src/pages/CompaniesPage/CompaniesPage.tsx
@@ -1,3 +1,4 @@
+import CompanyInfoForm from '@/components/common/CompanyInfoForm/CompanyInfoForm';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -8,23 +9,8 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
-import {
-  Command,
-  CommandGroup,
-  CommandItem,
-  CommandList,
-} from '@/components/ui/command';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover';
-import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
-import { Check, ChevronsUpDown, Plus } from 'lucide-react';
-import { useState } from 'react';
+import { Plus } from 'lucide-react';
 import { Link } from 'react-router';
 
 const DATA = [
@@ -36,29 +22,7 @@ const DATA = [
   { id: 6, name: '쿠팡', job: '프로덕트 디자이너' },
 ];
 
-const EMPLOYMENT_TYPE = [
-  {
-    value: '정규직',
-    label: '정규직',
-  },
-  {
-    value: '계약직',
-    label: '계약직',
-  },
-  {
-    value: '인턴',
-    label: '인턴',
-  },
-  {
-    value: '프리랜서',
-    label: '프리랜서',
-  },
-];
-
 function CompaniesPage() {
-  const [open, setOpen] = useState(false);
-  const [value, setValue] = useState('');
-
   const hasData = DATA.length > 0;
 
   return (
@@ -100,113 +64,9 @@ function CompaniesPage() {
               </div>
             </AlertDialogTitle>
 
-            <div id="회사 정보를 입력해주세요." className="flex flex-col gap-4">
-              <div className="flex gap-4">
-                <div>
-                  <Label htmlFor="company" isRequired>
-                    회사명
-                  </Label>
-                  <Input
-                    id="company"
-                    className="w-[323px]"
-                    type="text"
-                    placeholder="지원하려고 하는 회사명을 입력해주세요."
-                    required
-                  />
-                </div>
+            <CompanyInfoForm />
 
-                <div className="w-full">
-                  <Label htmlFor="job" isRequired>
-                    직무 선택
-                  </Label>
-                  <Input
-                    id="job"
-                    type="text"
-                    placeholder="지원하려는 직무를 선택해주세요."
-                    required
-                  />
-                </div>
-
-                <div className="w-full">
-                  <Label htmlFor="type">채용 형태</Label>
-                  <Popover open={open} onOpenChange={setOpen}>
-                    <PopoverTrigger asChild>
-                      <Button
-                        id="type"
-                        variant="outline"
-                        role="combobox"
-                        aria-expanded={open}
-                        data-empty={!value}
-                        className="flex justify-between w-full data-[empty=true]:text-muted-foreground"
-                      >
-                        {value
-                          ? EMPLOYMENT_TYPE.find((type) => type.value === value)
-                              ?.label
-                          : '채용 형태를 선택해주세요.'}
-                        <ChevronsUpDown className="opacity-50" />
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-[200px] p-0">
-                      <Command>
-                        <CommandList>
-                          <CommandGroup>
-                            {EMPLOYMENT_TYPE.map((type) => (
-                              <CommandItem
-                                key={type.value}
-                                value={type.value}
-                                onSelect={(currentValue) => {
-                                  setValue(
-                                    currentValue === value ? '' : currentValue,
-                                  );
-                                  setOpen(false);
-                                }}
-                              >
-                                {type.label}
-                                <Check
-                                  className={cn(
-                                    'ml-auto',
-                                    value === type.value
-                                      ? 'opacity-100'
-                                      : 'opacity-0',
-                                  )}
-                                />
-                              </CommandItem>
-                            ))}
-                          </CommandGroup>
-                        </CommandList>
-                      </Command>
-                    </PopoverContent>
-                  </Popover>
-                </div>
-              </div>
-
-              <div>
-                <Label htmlFor="url">관련 공고 URL</Label>
-                <div className="relative">
-                  <span className="absolute top-1/2 left-3 -translate-y-1/2  text-sm text-muted-foreground ">
-                    https://
-                  </span>
-                  <div className="absolute left-[68px] w-px bg-input h-9" />
-                  <Input
-                    id="url"
-                    type="text"
-                    placeholder="example.com"
-                    className="pl-[78px]"
-                  />
-                </div>
-              </div>
-
-              <div>
-                <Label htmlFor="description">회사 설명</Label>
-                <Textarea
-                  id="description"
-                  placeholder="더욱 정확한 정보를 위한 설명도 함께 작성해주세요."
-                  className="min-h-40"
-                />
-              </div>
-            </div>
-
-            <AlertDialogFooter className="sm:justify-between">
+            <AlertDialogFooter className="sm:justify-between mt-[26px]">
               <AlertDialogCancel>취소</AlertDialogCancel>
               <AlertDialogAction>확인</AlertDialogAction>
             </AlertDialogFooter>


### PR DESCRIPTION
## 변경 사항
- 회사 정보 모달
   - `회사 정보 폼 <CompanyInfoForm />` 컴포넌트 분리
   - `회사 추가 모달 <AddcompanyDialog />` 컴포넌트 분리
   - 회사별 맞춤 관리 페이지에서 사용자의 회사 정보 모달 추가

- QA 체크리스트 수정
  - 문구 정렬
  - 예상면접질문 문구 제거
  - 사이드바 - 하위 메뉴 포커스
  - 사이드바 - 회사 추가 버튼 클릭 시, 회사 추가 모달 추가

| 사용자의 회사 정모 모달 | 사이드바 하위 메뉴 포커스
| --- | --- |
| <img width="1546" height="765" alt="image" src="https://github.com/user-attachments/assets/83efe117-7776-4197-a1d8-e30460c1e373" /> | <img width="693" height="610" alt="image" src="https://github.com/user-attachments/assets/d5d9aa3f-e657-45b6-973e-25f99c876925" /> |




## 기타
